### PR TITLE
2.0.5 CrashLoopBackoff, change to 2.0.18

### DIFF
--- a/kubernetes/fluentd-daemonset-filtered.yaml
+++ b/kubernetes/fluentd-daemonset-filtered.yaml
@@ -25,7 +25,7 @@ spec:
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor
-        image: gcr.io/google-containers/fluentd-gcp:2.0.5
+        image: gcr.io/google-containers/fluentd-gcp:2.0.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/kubernetes/fluentd-daemonset.yaml
+++ b/kubernetes/fluentd-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor
-        image: gcr.io/google-containers/fluentd-gcp:2.0.5
+        image: gcr.io/google-containers/fluentd-gcp:2.0.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:


### PR DESCRIPTION
Following this lab

[https://google.qwiklabs.com/focuses/1244?parent=catalog](https://google.qwiklabs.com/focuses/1244?parent=catalog)

I get error CrashLoopBackoff when I execute

`kubectl apply -f kubernetes/fluentd-daemonset.yaml`
`kubectl apply -f kubernetes/fluentd-daemonset-filtered.yaml`

Change to 2.0.18, fix the error