### PR TITLE
Updated fluentd-daemonset and test-logger deployment to use 1.16 API

### DIFF
--- a/kubernetes/fluentd-daemonset.yaml
+++ b/kubernetes/fluentd-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/kubernetes/test-logger.yaml
+++ b/kubernetes/test-logger.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-logger


### PR DESCRIPTION
Updating to use 1.16 API on daemonset and deployment