### PR TITLE
added selector.matchLabels as required by kube 1.8+, delete template.…

### DIFF
--- a/kubernetes/fluentd-daemonset.yaml
+++ b/kubernetes/fluentd-daemonset.yaml
@@ -12,6 +12,7 @@ spec:
     matchLabels:
       k8s-app: fluentd-gcp-custom
       version: v3.2.0
+      name: fluentd-gcp-v3.2.0
   template:
     metadata:
       annotations:
@@ -20,6 +21,7 @@ spec:
       labels:
         k8s-app: fluentd-gcp-custom
         version: v3.2.0
+        name: fluentd-gcp-v3.2.0
     spec:
       containers:
       - env:
@@ -121,8 +123,4 @@ spec:
           name: fluentd-gcp-config
         name: config-volume
 #[END configMapNameDS]
-  templateGeneration: 2
-  updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 1
-    type: RollingUpdate
+

--- a/kubernetes/test-logger.yaml
+++ b/kubernetes/test-logger.yaml
@@ -4,6 +4,9 @@ metadata:
   name: test-logger
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      component: test-logger
   template:
     metadata:
       labels:


### PR DESCRIPTION
Added selector.matchLabels as required by kube 1.8+, I missed this in my last PR
Delete template.generation from Daemonset as this is deprecated
Delete block for rolling update from Daemonset as this is now the default so simplifies the yaml